### PR TITLE
Fix bundler cache in `.circleci/config.yml` and add tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
             bundle install --jobs=4 --retry=3 --path vendor/bundle
       - save_cache:
           paths:
-            - ./vendor/bundle
+            - tests/api/vendor/bundle
           key: v1-ruby-dependencies-{{ checksum "tests/api/Gemfile.lock" }}
 
       # requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,8 @@
+.PHONY: main ci_validate ci_execute
+
 main:
 	dot docs/state_machine.dot -Tpng > docs/state_machine.png
+ci_validate:
+	sudo circleci config validate
+ci_execute:
+	sudo circleci local execute


### PR DESCRIPTION
This fixes bundler cache on circle (wrong, relative path to
`vendor/bundle`) and adds two top-level tasks to validate config
(`ci_validate`) and run build in local container (`ci_execute`).